### PR TITLE
graph.py: Removed function call is no longer defined

### DIFF
--- a/grash/graph.py
+++ b/grash/graph.py
@@ -80,7 +80,6 @@ class Graph:
             self._file_path = file_path
             self._filename = os.path.basename(file_path)
             self._type = magic.from_file(self._file_path)
-            self._get_type()
             self._deps = []
 
         @property


### PR DESCRIPTION
Removed get_type() call from Node's __init__().